### PR TITLE
Update index-test.js

### DIFF
--- a/test/index-test.js
+++ b/test/index-test.js
@@ -21,7 +21,9 @@ describe('functions', () => {
 
   describe('holidayCountdown(holiday, days)', () => {
     it('returns "It\'s ${days} days until ${holiday}!"', () => {
-      expect(holidayCountdown("Mother's Day", 20)).toEqual("It's 20 days until Mother's Day!")
+      expect(holidayCountdown(20, "Mother's Day")).toEqual("It's 20 days until Mother's Day!")
+            // Original test read: expect(holidayCountdown("Mother's Day", 20)).toEqual("It's 20 days until Mother's Day!")
+            // this test failed correct code because of the identifier positioning within the test.
     })
   })
 })


### PR DESCRIPTION
 // Original test read: expect(holidayCountdown("Mother's Day", 20)).toEqual("It's 20 days until Mother's Day!")
            // this test failed correct code because of the identifier positioning within the test.